### PR TITLE
fixed datafiles to also display public files, added some comments

### DIFF
--- a/src/controllers/data_controller.js
+++ b/src/controllers/data_controller.js
@@ -1,9 +1,11 @@
 import Data from '../models/data_model';
 
+// gets a single datafile
 export const getDataFile = async (fileName, user) => {
   return Data.findOne({ fileName, $or: [{ user }, { user: null }] });
 };
 
+// adds datafile (will update ones with same filename)
 export const insertData = async (data, user) => {
   const { fileName, url } = data;
   let dataFile = await Data.findOne({ fileName, user });
@@ -19,15 +21,22 @@ export const insertData = async (data, user) => {
   return dataFile;
 };
 
+// get all datafiles for testing purposes
 export const getDataFiles = async () => {
   return Data.find().sort('-createdAt');
 };
 
+// gets all user datafiles + public ones (null userID)
 export const getUserData = async (userID) => {
-  return Data.find({ user: userID }).sort('-createdAt');
+  return Data.find({
+    $or: [
+      { user: userID },
+      { user: null },
+    ],
+  }).sort('-createdAt');
 };
 
-// replace all virtual filenames with their real URLs
+// replace all virtual filenames with their real URLs during parsing
 export const insertAllUrls = async (parsedOutput, userID) => {
   try {
     const response = await Promise.all(parsedOutput.map(async (object) => {

--- a/src/controllers/dofile_controller.js
+++ b/src/controllers/dofile_controller.js
@@ -73,6 +73,7 @@ const tutorials = [
   { fileName: 'tutorial 3', content: '// tutorial 3', tutorialID: 'tutorial-3' },
 ];
 
+// called upon new user registration to add these tutorials
 export const addTutorials = async (userID) => {
   return Promise.all(tutorials.map(async (tutorial) => {
     const newTutorial = new DoFile({ ...tutorial, author: userID });

--- a/src/controllers/logfile_controller.js
+++ b/src/controllers/logfile_controller.js
@@ -1,7 +1,6 @@
 import LogFile from '../models/logfile_model';
 
 export const createLogFile = (req, res) => {
-  // res.send('post should be created and returned');
   LogFile.findOneAndDelete({ fileName: req.body.fileName, author: req.user._id }) // delete a file of the same name if it exists
     .then((result1) => {
       const logfile = new LogFile({
@@ -20,17 +19,15 @@ export const createLogFile = (req, res) => {
 };
 
 export const getLogFile = (req, res) => {
-  // res.send('single post looked up');
   LogFile.findOne({ fileName: req.body.fileName, author: req.user._id })
     .then((result) => {
-      res.send(result);
+      res.json(result);
     }).catch((error) => {
       res.status(500).json({ error });
     });
 };
 
 export const getLogFiles = (req, res) => {
-  // res.send('single post looked up');
   LogFile.find({ author: req.user._id })
     .then((result) => {
       res.json(result);
@@ -50,6 +47,7 @@ export const deleteLogFile = (req, res) => {
 };
 
 // saves all dofiles that are in a dictionary of filename: content
+// this happens after execution from flask
 export const saveLogFiles = async (logfiles, userID) => {
   if (!userID) return [null];
   try {

--- a/src/controllers/stata_controller.js
+++ b/src/controllers/stata_controller.js
@@ -1,5 +1,6 @@
 import axios from 'axios';
 
+// microservice url to post AST parsed output to
 const FLASK_URL = 'https://open-stata-other-api.herokuapp.com/do';
 
 // eslint-disable-next-line import/prefer-default-export

--- a/src/controllers/user_controller.js
+++ b/src/controllers/user_controller.js
@@ -45,6 +45,7 @@ export const signup = async (req, res, next) => {
 
     const newUser = new User({ email, password, username });
     const newUserToken = await newUser.save();
+    // when a new user signs up, we add in the default tutorials to their account
     await addTutorials(newUser._id);
 
     console.log('success creating user');

--- a/src/routers/parse_router.js
+++ b/src/routers/parse_router.js
@@ -46,6 +46,7 @@ router.route('/')
     }
   });
 
+// testing route to check parsing only
 router.route('/test')
   .post(async (req, res) => {
     try {


### PR DESCRIPTION
# fixed datafiles to also display public files, added some comments

title. nothing else. returned datafiles may or may not have a `tutorialID` field, which must be sent along (and null sent if missing) during parsing, so the flask api can handle tutorial validation.


## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Referenced Issue(s)

Closes #28 